### PR TITLE
Added JMpq-v3 support

### DIFF
--- a/EclipseWurstPlugin/src/de/peeeq/eclipsewurstplugin/console/WurstREPL.java
+++ b/EclipseWurstPlugin/src/de/peeeq/eclipsewurstplugin/console/WurstREPL.java
@@ -470,7 +470,7 @@ public class WurstREPL {
 			
 			// then inject the script into the map
 			File outputMapscript = new File(compiledScript.getRawLocationURI());
-			try (MpqEditor mpqEditor = MpqEditorFactory.getEditor(testMap)) {
+			try (MpqEditor mpqEditor = MpqEditorFactory.getEditor(testMap, runArgs)) {
 				//			MpqEditor mpqEditor = new WinMpq("C:\\work\\WurstScript\\Wurstpack\\winmpq\\WinMPQ.exe");
 				mpqEditor.deleteFile("war3map.j");
 				mpqEditor.insertFile("war3map.j", Files.toByteArray(outputMapscript));
@@ -638,7 +638,7 @@ public class WurstREPL {
 		
 		MpqEditor mpqEditor = null;
 		if (mapFile != null) {
-			mpqEditor = MpqEditorFactory.getEditor(mapFile);
+			mpqEditor = MpqEditorFactory.getEditor(mapFile, runArgs);
 		}
 		WurstCompilerJassImpl compiler = new WurstCompilerJassImpl(gui, mpqEditor, runArgs);
 		compiler.setMapFile(mapFile);

--- a/EclipseWurstPlugin/src/de/peeeq/eclipsewurstplugin/ui/ExtractJurstCommand.java
+++ b/EclipseWurstPlugin/src/de/peeeq/eclipsewurstplugin/ui/ExtractJurstCommand.java
@@ -35,6 +35,7 @@ import de.peeeq.wurstio.mpq.MpqEditorFactory;
 import de.peeeq.wurstio.objectreader.BinaryDataInputStream;
 import de.peeeq.wurstio.objectreader.WCTFile;
 import de.peeeq.wurstio.objectreader.WCTFile.CustomTextTrigger;
+import de.peeeq.wurstscript.RunArgs;
 import de.peeeq.wurstscript.WLogger;
 import de.peeeq.wurstscript.jurst.ExtendedJurstLexer;
 import de.peeeq.wurstscript.jurst.antlr.JurstParser;
@@ -57,7 +58,7 @@ public class ExtractJurstCommand extends AbstractHandler implements IHandler {
 		try {
 			IPath mpqPath = file.getRawLocation();
 			File mpq = mpqPath.toFile();
-			MpqEditor mpqEd = MpqEditorFactory.getEditor(mpq);
+			MpqEditor mpqEd = MpqEditorFactory.getEditor(mpq, RunArgs.defaults());
 			byte[] tempWct = mpqEd.extractFile("war3map.wct");
 			mpqEd.close();
 			

--- a/Wurstpack/wehack.lua
+++ b/Wurstpack/wehack.lua
@@ -136,7 +136,7 @@ if havewurst then
 	wehack.addmenuseparator(wurstmenu)
 	
 	-- other tools
-	
+	wurst_useJmpq2 = TogMenuEntry:New(wurstmenu, "Use JMpq-v2 (deprecated)",nil,false)
 	
 	
 	function wurst_runfileexporter()
@@ -530,7 +530,7 @@ grim.log("running tool on save: "..cmdargs)
 		end
 		cmdline = cmdline .. " "..jh_path.."jasshelper\\common.j "..jh_path.."jasshelper\\blizzard.j \"" .. mappath .."\""
 		toolresult = 0
-		toolresult = wehack.runprocess2(cmdline)
+		toolresult = wehack.runprocess(cmdline)
 		if toolresult == 0 then 
 			mapvalid = true
 		else
@@ -570,6 +570,9 @@ grim.log("running tool on save: "..cmdargs)
 		end
 		if wurst_injectObjects.checked then
 			cmdline = cmdline .. " -injectobjects"
+		end
+		if wurst_useJmpq2.checked then
+			cmdline = cmdline .. " --jmpq2"
 		end
 		
 		-- cmdline = cmdline .. " -lib ./wurstscript/lib/"

--- a/de.peeeq.wurstscript/.classpath
+++ b/de.peeeq.wurstscript/.classpath
@@ -19,5 +19,6 @@
 	<classpathentry exported="true" kind="lib" path="lib/antlr-runtime-4.4.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/jna-4.0.0.jar"/>
 	<classpathentry kind="lib" path="lib/org.eclipse.jdt.annotation-2.0.0.jar"/>
+	<classpathentry kind="lib" path="lib/jmpq3.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/de.peeeq.wurstscript/build-jar.xml
+++ b/de.peeeq.wurstscript/build-jar.xml
@@ -7,7 +7,7 @@
 		<jar destfile="./dist/wurstscript.jar">
 			<manifest>
 				<attribute name="Main-Class" value="de.peeeq.wurstio.Main" />
-				<attribute name="Class-Path" value=". wurstscript_lib/log4j-1.2.16.jar wurstscript_lib/guava-14.0-rc1.jar wurstscript_lib/junit-4.10.jar wurstscript_lib/chardet.jar wurstscript_lib/jmpq2.jar wurstscript_lib/antlr-runtime-4.4.jar wurstscript_lib/jna-4.0.0.jar wurstscript_lib/org.eclipse.jdt.annotation-2.0.0.jar" />
+				<attribute name="Class-Path" value=". wurstscript_lib/log4j-1.2.16.jar wurstscript_lib/guava-14.0-rc1.jar wurstscript_lib/junit-4.10.jar wurstscript_lib/chardet.jar wurstscript_lib/jmpq2.jar wurstscript_lib/jmpq3.jar wurstscript_lib/antlr-runtime-4.4.jar wurstscript_lib/jna-4.0.0.jar wurstscript_lib/org.eclipse.jdt.annotation-2.0.0.jar" />
 			</manifest>
 			<fileset dir="./bin" />
 			<fileset dir="./resources" />
@@ -20,6 +20,7 @@
 		<copy file="./lib/chardet.jar" todir="./dist/wurstscript_lib" />
 		<copy file="./lib/velocity-1.7-dep.jar" todir="./dist/wurstscript_lib" />
 		<copy file="./lib/jmpq2.jar" todir="./dist/wurstscript_lib" />
+		<copy file="./lib/jmpq3.jar" todir="./dist/wurstscript_lib" />
 		<copy file="./lib/antlr-runtime-4.4.jar" todir="./dist/wurstscript_lib" />
 		<copy file="./lib/org.eclipse.jdt.annotation-2.0.0.jar" todir="./dist/wurstscript_lib" />
 		<copy file="./lib/jna-4.0.0.jar" todir="./dist/wurstscript_lib" />

--- a/de.peeeq.wurstscript/src-test/tests/wurstscript/tests/MpqTest.java
+++ b/de.peeeq.wurstscript/src-test/tests/wurstscript/tests/MpqTest.java
@@ -13,6 +13,7 @@ import com.google.common.io.Files;
 
 import de.peeeq.wurstio.mpq.MpqEditor;
 import de.peeeq.wurstio.mpq.MpqEditorFactory;
+import de.peeeq.wurstscript.RunArgs;
 
 public class MpqTest {
 
@@ -37,8 +38,7 @@ public class MpqTest {
 
 	@Test
 	public void test_extract() throws Exception {
-		MpqEditorFactory.setTempfolder(TEST_OUTPUT_PATH);
-		try (MpqEditor edit = MpqEditorFactory.getEditor(new File(TEST_W3X))) {
+		try (MpqEditor edit = MpqEditorFactory.getEditor(new File(TEST_W3X), RunArgs.defaults())) {
 			byte[] f = edit.extractFile("war3map.j");
 			// edit.insertFile(new File("./testscripts/mpq/test.w3x"), "war3map.j",
 			// f);
@@ -68,8 +68,7 @@ public class MpqTest {
 
 	@Test
 	public void test_insert() throws Exception {
-		MpqEditorFactory.setTempfolder(TEST_OUTPUT_PATH);
-		try (MpqEditor edit = MpqEditorFactory.getEditor(new File(TEST_W3X))) {
+		try (MpqEditor edit = MpqEditorFactory.getEditor(new File(TEST_W3X), RunArgs.defaults())) {
 			edit.insertFile("test.txt", Files.toByteArray(new File(
 					"./testscripts/mpq/test.txt")));
 		}
@@ -79,8 +78,7 @@ public class MpqTest {
 
 	@Test
 	public void test_delete() throws Exception {
-		MpqEditorFactory.setTempfolder(TEST_OUTPUT_PATH);
-		try (MpqEditor edit = MpqEditorFactory.getEditor(new File(TEST_W3X))) {
+		try (MpqEditor edit = MpqEditorFactory.getEditor(new File(TEST_W3X), RunArgs.defaults())) {
 			edit.deleteFile("test.txt");
 		}
 		Assert.assertTrue(true);

--- a/de.peeeq.wurstscript/src/de/peeeq/wurstio/Main.java
+++ b/de.peeeq.wurstscript/src/de/peeeq/wurstio/Main.java
@@ -86,7 +86,7 @@ public class Main {
 			String mapFilePath = runArgs.getMapFile();
 			if (runArgs.isExtractImports()) {
 				File mapFile = new File(mapFilePath);
-				ImportFile.extractImportedFiles(mapFile);
+				ImportFile.extractImportedFiles(mapFile, runArgs);
 				return;
 			}
 
@@ -120,7 +120,7 @@ public class Main {
 
 					
 				if (mapFilePath != null) {
-					try (MpqEditor mpqEditor = MpqEditorFactory.getEditor(new File(mapFilePath))) {
+					try (MpqEditor mpqEditor = MpqEditorFactory.getEditor(new File(mapFilePath), runArgs)) {
 						CharSequence mapScript = doCompilation(gui, mpqEditor, runArgs);
 						if (mapScript != null) {
 							gui.sendProgress("Writing to map", 0.99);

--- a/de.peeeq.wurstscript/src/de/peeeq/wurstio/map/importer/ImportFile.java
+++ b/de.peeeq.wurstscript/src/de/peeeq/wurstio/map/importer/ImportFile.java
@@ -13,6 +13,7 @@ import com.google.common.io.LittleEndianDataInputStream;
 
 import de.peeeq.wurstio.mpq.MpqEditor;
 import de.peeeq.wurstio.mpq.MpqEditorFactory;
+import de.peeeq.wurstscript.RunArgs;
 import de.peeeq.wurstscript.WLogger;
 
 
@@ -123,7 +124,7 @@ public class ImportFile {
 		mpq.insertFile("war3map.imp",Files.toByteArray(temp));	
 	}
 	
-	public static void extractImportedFiles(File mapFile) {
+	public static void extractImportedFiles(File mapFile, RunArgs runArgs) {
 		if (!mapFile.exists() || !mapFile.isFile()) {
 			JOptionPane.showMessageDialog(null, "Map " + mapFile.getAbsolutePath() + " does not exist.");
 			return;
@@ -131,7 +132,7 @@ public class ImportFile {
 		try {
 			File mapTemp = File.createTempFile("temp", "w3x");
 			Files.copy(mapFile, mapTemp);
-			try (MpqEditor ed = MpqEditorFactory.getEditor(mapTemp)) {
+			try (MpqEditor ed = MpqEditorFactory.getEditor(mapTemp, runArgs)) {
 				File importDirectory = getImportDirectory(mapFile);
 				LinkedList<String> failed = extractImportedFiles(ed, importDirectory);
 				if (failed.isEmpty()){

--- a/de.peeeq.wurstscript/src/de/peeeq/wurstio/mpq/Jmpq3BasedEditor.java
+++ b/de.peeeq.wurstscript/src/de/peeeq/wurstio/mpq/Jmpq3BasedEditor.java
@@ -1,0 +1,70 @@
+package de.peeeq.wurstio.mpq;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import com.google.common.base.Preconditions;
+
+import de.peeeq.jmpq3.JMpqEditor;
+import de.peeeq.jmpq3.JMpqException;
+
+
+
+class Jmpq3BasedEditor implements MpqEditor {
+
+	private JMpqEditor editor;
+
+	private JMpqEditor getEditor() {
+		if (editor == null) {
+			throw new RuntimeException("editor already closed");
+		}
+		return editor;
+	}
+	public Jmpq3BasedEditor(File mpqArchive) throws Exception {
+		Preconditions.checkNotNull(mpqArchive);
+		if (!mpqArchive.exists()) {
+			throw new FileNotFoundException("not found: " + mpqArchive);
+		}
+		this.editor = new JMpqEditor(mpqArchive);
+	}
+
+	@Override
+	public void insertFile(String filenameInMpq, byte[] contents) throws Exception {
+		File temp = File.createTempFile("peq", "wurst");
+		FileOutputStream fos = new FileOutputStream(temp);
+		fos.write(contents);
+		fos.close();
+		getEditor().insertFile(filenameInMpq, temp, false);
+	}
+	
+	
+	@Override
+	public byte[] extractFile(String fileToExtract)	throws Exception {
+		File temp = File.createTempFile("peq", "wurst");
+		getEditor().extractFile(fileToExtract, temp);
+		return Files.readAllBytes(temp.toPath());
+	}
+
+
+	@Override
+	public void deleteFile(String filenameInMpq) throws Exception {
+		getEditor().deleteFile(filenameInMpq);
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (editor != null) {
+			try {
+				editor.close();
+			} catch (JMpqException e) {
+				throw new IOException(e);
+			}
+			editor = null;
+		}
+	}
+
+}
+

--- a/de.peeeq.wurstscript/src/de/peeeq/wurstio/mpq/MpqEditorFactory.java
+++ b/de.peeeq.wurstscript/src/de/peeeq/wurstio/mpq/MpqEditorFactory.java
@@ -2,17 +2,16 @@ package de.peeeq.wurstio.mpq;
 
 import java.io.File;
 
+import de.peeeq.wurstscript.RunArgs;
+
 
 public class MpqEditorFactory {
-	private static String tempfolder = "";
 	
-	static public MpqEditor getEditor(File f) throws Exception {
-		return new Jmpq2BasedEditor(f);
-	}
-
-	
-
-	public static void setTempfolder(String tempfolder) {
-		MpqEditorFactory.tempfolder = tempfolder;
+	static public MpqEditor getEditor(File f, RunArgs args) throws Exception {
+		if(args.useJmpq2()){
+			return new Jmpq2BasedEditor(f);
+		}else{
+			return new Jmpq3BasedEditor(f);
+		}
 	}
 }

--- a/de.peeeq.wurstscript/src/de/peeeq/wurstio/objectreader/WCTFile.java
+++ b/de.peeeq.wurstscript/src/de/peeeq/wurstio/objectreader/WCTFile.java
@@ -11,6 +11,7 @@ import com.google.common.collect.Lists;
 
 import de.peeeq.wurstio.mpq.MpqEditor;
 import de.peeeq.wurstio.mpq.MpqEditorFactory;
+import de.peeeq.wurstscript.RunArgs;
 
 public class WCTFile {
 	
@@ -84,7 +85,7 @@ public class WCTFile {
 	public static void main(String[] args) throws Exception {
 		
 		File mpq = new File("/home/peter/work/dvs/dvs.w3x");
-		try (MpqEditor ed = MpqEditorFactory.getEditor(mpq)) {
+		try (MpqEditor ed = MpqEditorFactory.getEditor(mpq, RunArgs.defaults())) {
 			byte[] wtc = ed.extractFile("war3map.wct");
 			try (BinaryDataInputStream bdin = new BinaryDataInputStream(new ByteArrayInputStream(wtc), true)) {
 				WCTFile tr = fromStream(bdin);

--- a/de.peeeq.wurstscript/src/de/peeeq/wurstscript/RunArgs.java
+++ b/de.peeeq.wurstscript/src/de/peeeq/wurstscript/RunArgs.java
@@ -34,6 +34,7 @@ public class RunArgs {
 	private RunOption optionExtractImports;
 	private RunOption optionStartServer;
 	private RunOption optionGenerateLua;
+	private RunOption optionUseJmpq2;
 	
 	private class RunOption {
 		final String name;
@@ -84,6 +85,7 @@ public class RunArgs {
 		// backends
 		optionGenerateLua = addOption("lua", "generate lua output");
 		// other
+		optionUseJmpq2 = addOption("-jmpq2", "Use JMpq-v2 as mpq editor");
 		optionGui = addOption("gui", "Show a graphical user interface (progress bar and error window).");
 		addOptionWithArg("lib", "The next argument should be a library folder which is lazily added to the build.", arg -> {
 			libDirs.add(new File(arg));
@@ -247,5 +249,9 @@ public class RunArgs {
 	
 	public boolean isUncheckedDispatch() {
 		return uncheckedDispatch.isSet;
+	}
+	
+	public boolean useJmpq2(){
+		return optionUseJmpq2.isSet;
 	}
 }


### PR DESCRIPTION
Important features:
-Decreased ram usage significantly
-Can open and rebuild mpqs including files that are compressed using other compression algorithms as zlib
-Much more stable implementation and cleaner code -> easy to add features
-Better resulting filesize

I've been testing Jmpq-v3 the last few days on different maps without problems so far. 
Since v3 was intended to replace v2 iam not going to fix any bug in v2. So the tickets: #327 #321 #355 and #323 can be closed. 
 