### PR TITLE
Fixed leave-detection

### DIFF
--- a/Wurstpack/wurstscript/lib/systems/OnUnitEnterLeave.wurst
+++ b/Wurstpack/wurstscript/lib/systems/OnUnitEnterLeave.wurst
@@ -5,26 +5,10 @@ import Unit
 import Trigger
 import Player
 import TempGroups
-import PrintingHelper
 import AbilityObjEditing
-import ObjectIds
 import initlater RegisterEvents
 
-
-
-
 constant eventTrigger = CreateTrigger()
-constant DO_INDEXING = true
-
-class UnitIndex
-	unit u
-	
-	construct(unit u)
-		this.u = u
-		u.setUserData(this castTo int)
-		
-	ondestroy
-		u.setUserData(0)
 
 public function getEnterLeaveUnit() returns unit
 	return tempUnit
@@ -36,23 +20,19 @@ public function onLeave(code c)
 	eventTrigger.addAction(c)
 
 unit tempUnit = null
-
-function enter()
-	tempUnit = GetEnteringUnit()..addAbility(ABILITY_ID)..makeAbilityPermanent(ABILITY_ID, true)
-	if DO_INDEXING
-		new UnitIndex(tempUnit)
-	eventTrigger.evaluate()
-	tempUnit = null
 	
 init
 	CreateTrigger()..registerEnterRegion(boundRegion, null)
-	..addCondition(Condition(() -> enter()))
+	..addCondition(Condition(() -> begin
+		tempUnit = GetEnteringUnit()..addAbility(ABILITY_ID)..makeAbilityPermanent(ABILITY_ID, true)
+		eventTrigger.evaluate()
+		tempUnit = null
+	end))
 	
 	registerPlayerUnitEvent(EVENT_PLAYER_UNIT_ISSUED_ORDER, () -> begin
-		let leavingUnit = GetFilterUnit()
+		let leavingUnit = GetTriggerUnit()
 		if leavingUnit.getAbilityLevel(ABILITY_ID) == 0
 			tempUnit = leavingUnit
-			destroy tempUnit.getUserData() castTo UnitIndex
 			eventTrigger.execute()
 			tempUnit = null
 	end)
@@ -60,13 +40,16 @@ init
 	for i = 0 to bj_MAX_PLAYER_SLOTS-1
 		players[i].setAbilityAvailable(ABILITY_ID, false)
     
-	GroupEnumUnitsInRect(ENUM_GROUP, boundRect, Filter(() -> enter()))
-    
+	GroupEnumUnitsInRect(ENUM_GROUP, boundRect, Filter(() -> begin
+		tempUnit = GetFilterUnit()..addAbility(ABILITY_ID)..makeAbilityPermanent(ABILITY_ID, true)
+		eventTrigger.evaluate()
+		tempUnit = null
+	end))
 
 int ABILITY_ID = '!e@$'
 
 @compiletime function generateAbility()
 	new AbilityDefinitionDefend(ABILITY_ID)
-	..setName("Deindex Detect")..setEditorSuffix("(Unit Indexer)")
+	..setName("Leave Detect")..setEditorSuffix("(OnUnitEnterLeave)")
 	..setArtCaster("")..setIconNormal("")..setRace(Race.Unknown)
 	


### PR DESCRIPTION
- fixed leave detection in general (leaving units were not detected due to wrong event response)
- fixed leave detection on preplaced units (wasnt working at all, wrong event response)
- removed the minimal unit indexer, it doesnt belong here and there is a real unit indexer in the stdlib which is 100% compatible