### PR TITLE
[stl] add damage type implementation

### DIFF
--- a/Wurstpack/wurstscript/lib/systems/DamageType.wurst
+++ b/Wurstpack/wurstscript/lib/systems/DamageType.wurst
@@ -70,7 +70,7 @@ function after()
     dealCodeDamage(tempDat.source, tempDat.target, tempDat.damage)
 
     destroy tempDat
-    DestroyTimer(time)
+    time.release()
 
 
 function getUnitBonusSpellResistance(unit u) returns real
@@ -114,8 +114,8 @@ function handler() returns bool
             tempDat.source = GetEventDamageSource()
             tempDat.damage = attemptedDamage
 
-            CreateTimer()..setData(tempDat castTo int)
-                         ..start(0., function after)
+            getTimer()..setData(tempDat castTo int)
+                      ..start(0., function after)
         else
             dealCodeDamage(GetEventDamageSource(), tU, 2.*attemptedDamage)
 

--- a/Wurstpack/wurstscript/lib/systems/DamageType.wurst
+++ b/Wurstpack/wurstscript/lib/systems/DamageType.wurst
@@ -2,143 +2,144 @@
 // DamageDetection handler. Typically this means differentiating between spells
 // and basic attacks.
 package DamageType
-    import AbilityObjEditing
-    import ClosureForGroups
-    import DamageDetection
-    import OnUnitEnterLeave
 
-    class DelayDat
-        unit target
-        unit source
-        real damage
+import AbilityObjEditing
+import ClosureForGroups
+import DamageDetection
+import OnUnitEnterLeave
 
-
-    public enum DamageType
-        NULLED
-        ATTACK
-        SPELL
-        CODE
+class DelayDat
+    unit target
+    unit source
+    real damage
 
 
-    @configurable var useBonusCalculator = false
+public enum DamageType
+    NULLED
+    ATTACK
+    SPELL
+    CODE
 
 
-    // ConvertAttackType(7) is a hidden attack type with some unique
-    // properties. For more information see goo.gl/9k8tn .
-    constant ATTACK_TYPE_UNIVERSAL = ConvertAttackType(7)
-    constant DAMAGE_TYPE_CHECK_ID  = '!dt*'
+@configurable var useBonusCalculator = false
 
 
-    var lastDamageType = DamageType.NULLED
-    function getDamageType() returns DamageType
-        let sourceDamage = GetEventDamage()
-        if lastDamageType == DamageType.CODE
-            return DamageType.CODE
-        else if sourceDamage > 0.
-            return DamageType.ATTACK
-        else if sourceDamage < 0.
-            return DamageType.SPELL
-
-        return DamageType.NULLED
+// ConvertAttackType(7) is a hidden attack type with some unique
+// properties. For more information see goo.gl/9k8tn .
+constant ATTACK_TYPE_UNIVERSAL = ConvertAttackType(7)
+constant DAMAGE_TYPE_CHECK_ID  = '!dt*'
 
 
-    function dealCodeDamage(unit who, unit target, real damage)
-        let prevType   = lastDamageType
-        let hp         = target.getHP() - .405
-        lastDamageType = DamageType.CODE
+var lastDamageType = DamageType.NULLED
+function getDamageType() returns DamageType
+    let sourceDamage = GetEventDamage()
+    if lastDamageType == DamageType.CODE
+        return DamageType.CODE
+    else if sourceDamage > 0.
+        return DamageType.ATTACK
+    else if sourceDamage < 0.
+        return DamageType.SPELL
 
-        if hp > damage
-            target.setHP(hp - damage + .405)
-            UnitDamageTarget(who, target, 0. , true, false, ATTACK_TYPE_UNIVERSAL, DAMAGE_TYPE_UNIVERSAL, null)
+    return DamageType.NULLED
+
+
+function dealCodeDamage(unit who, unit target, real damage)
+    let prevType   = lastDamageType
+    let hp         = target.getHP() - .405
+    lastDamageType = DamageType.CODE
+
+    if hp > damage
+        target.setHP(hp - damage + .405)
+        UnitDamageTarget(who, target, 0. , true, false, ATTACK_TYPE_UNIVERSAL, DAMAGE_TYPE_UNIVERSAL, null)
+    else
+        // Deal damage using two separate components. The
+        // ATTACK_TYPE_UNIVERSAL case will deal damage to units of all armor
+        // types, even if that armor would otherwise block all damage. The
+        // ATTACK_TYPE_MAGIC case affect ethereal units, whereas other
+        // attack types do not.
+        UnitDamageTarget(who, target, 1000000. + damage, true, false, ATTACK_TYPE_UNIVERSAL, DAMAGE_TYPE_UNIVERSAL, null)
+        UnitDamageTarget(who, target, 1000000. + damage, true, false, ATTACK_TYPE_MAGIC,     DAMAGE_TYPE_UNIVERSAL, null)
+
+    lastDamageType = prevType
+
+
+function after()
+    let      time    = GetExpiredTimer()
+    DelayDat tempDat = time.getData() castTo DelayDat
+
+    dealCodeDamage(tempDat.source, tempDat.target, tempDat.damage)
+
+    destroy tempDat
+    DestroyTimer(time)
+
+
+function getUnitBonusSpellResistance(unit u) returns real
+    let prevType = lastDamageType
+    let life     = u.getHP()
+    var scale    = u.getMaxHP()
+
+    u.setHP(scale)
+    lastDamageType = CODE
+    UnitDamageTarget(u, u, -scale/2., false, false, null, DAMAGE_TYPE_UNIVERSAL, null)
+    scale = 2.*(scale - u.getHP())/scale
+    u.setHP(life)
+
+    lastDamageType = prevType
+    return scale
+
+
+// This is the method that will invert any negative spell damage. To
+// function properly, it *must* be the first handler in the
+// DamageDetection handlers. To ensure this, simply import DamageType
+// in any package where you also import DamageDetection (so long as you
+// require the DamageType feature).
+function handler() returns bool
+    if getDamageType() == DamageType.SPELL
+        var attemptedDamage = -1.*GetEventDamage()
+        let tU              = GetTriggerUnit()
+
+        if useBonusCalculator
+            let scale = getUnitBonusSpellResistance(tU)
+
+            if scale > 1.
+                attemptedDamage = attemptedDamage*(scale + 1.)/2.
+
+
+        let sampledLife = tU.getHP() - .405
+        if sampledLife >= attemptedDamage and sampledLife <= 2.*attemptedDamage
+            tU.setHP(sampledLife - attemptedDamage)
+
+            let tempDat = new DelayDat
+            tempDat.target = tU
+            tempDat.source = GetEventDamageSource()
+            tempDat.damage = attemptedDamage
+
+            CreateTimer()..setData(tempDat castTo int)
+                         ..start(0., function after)
         else
-            // Deal damage using two separate components. The
-            // ATTACK_TYPE_UNIVERSAL case will deal damage to units of all armor
-            // types, even if that armor would otherwise block all damage. The
-            // ATTACK_TYPE_MAGIC case affect ethereal units, whereas other
-            // attack types do not.
-            UnitDamageTarget(who, target, 1000000. + damage, true, false, ATTACK_TYPE_UNIVERSAL, DAMAGE_TYPE_UNIVERSAL, null)
-            UnitDamageTarget(who, target, 1000000. + damage, true, false, ATTACK_TYPE_MAGIC,     DAMAGE_TYPE_UNIVERSAL, null)
+            dealCodeDamage(GetEventDamageSource(), tU, 2.*attemptedDamage)
 
-        lastDamageType = prevType
+    return false
 
 
-    function after()
-        let      time    = GetExpiredTimer()
-        DelayDat tempDat = time.getData() castTo DelayDat
-
-        dealCodeDamage(tempDat.source, tempDat.target, tempDat.damage)
-
-        destroy tempDat
-        DestroyTimer(time)
-
-
-    function getUnitBonusSpellResistance(unit u) returns real
-        let prevType = lastDamageType
-        let life     = u.getHP()
-        var scale    = u.getMaxHP()
-
-        u.setHP(scale)
-        lastDamageType = CODE
-        UnitDamageTarget(u, u, -scale/2., false, false, null, DAMAGE_TYPE_UNIVERSAL, null)
-        scale = 2.*(scale - u.getHP())/scale
-        u.setHP(life)
-
-        lastDamageType = prevType
-        return scale
-
-
-    // This is the method that will invert any negative spell damage. To
-    // function properly, it *must* be the first handler in the
-    // DamageDetection handlers. To ensure this, simply import DamageType
-    // in any package where you also import DamageDetection (so long as you
-    // require the DamageType feature).
-    function handler() returns bool
-        if getDamageType() == DamageType.SPELL
-            var attemptedDamage = -1.*GetEventDamage()
-            let tU              = GetTriggerUnit()
-
-            if useBonusCalculator
-                let scale = getUnitBonusSpellResistance(tU)
-
-                if scale > 1.
-                    attemptedDamage = attemptedDamage*(scale + 1.)/2.
-
-
-            let sampledLife = tU.getHP() - .405
-            if sampledLife >= attemptedDamage and sampledLife <= 2.*attemptedDamage
-                tU.setHP(sampledLife - attemptedDamage)
-
-                let tempDat = new DelayDat
-                tempDat.target = tU
-                tempDat.source = GetEventDamageSource()
-                tempDat.damage = attemptedDamage
-
-                CreateTimer()..setData(tempDat castTo int)
-                             ..start(0., function after)
-            else
-                dealCodeDamage(GetEventDamageSource(), tU, 2.*attemptedDamage)
+init
+    onEnter(() -> begin
+        GetTriggerUnit()..addAbility(          DAMAGE_TYPE_CHECK_ID)
+                        ..makeAbilityPermanent(DAMAGE_TYPE_CHECK_ID, true)
 
         return false
+    end)
+    forUnitsInRect(bj_mapInitialPlayableArea, (unit iter) -> begin
+        iter..addAbility(          DAMAGE_TYPE_CHECK_ID)
+            ..makeAbilityPermanent(DAMAGE_TYPE_CHECK_ID, true)
+    end)
+
+    addOnDamageFunc(Condition(function handler))
 
 
-    init
-        onEnter(() -> begin
-            GetTriggerUnit()..addAbility(          DAMAGE_TYPE_CHECK_ID)
-                            ..makeAbilityPermanent(DAMAGE_TYPE_CHECK_ID, true)
-
-            return false
-        end)
-        forUnitsInRect(bj_mapInitialPlayableArea, (unit iter) -> begin
-            iter..addAbility(          DAMAGE_TYPE_CHECK_ID)
-                ..makeAbilityPermanent(DAMAGE_TYPE_CHECK_ID, true)
-        end)
-
-        addOnDamageFunc(Condition(function handler))
-
-
-    @compiletime function generateAbility()
-        new AbilityDefinitionRunedBracers(DAMAGE_TYPE_CHECK_ID)
-            ..setName("Runed Bracer Dummy")
-            ..setEditorSuffix("(DamageType)")
-            ..setItemAbility(false)
-            ..setDamageReduction(1, 2.)
+@compiletime function generateAbility()
+    new AbilityDefinitionRunedBracers(DAMAGE_TYPE_CHECK_ID)
+        ..setName("Runed Bracer Dummy")
+        ..setEditorSuffix("(DamageType)")
+        ..setItemAbility(false)
+        ..setDamageReduction(1, 2.)

--- a/Wurstpack/wurstscript/lib/systems/DamageType.wurst
+++ b/Wurstpack/wurstscript/lib/systems/DamageType.wurst
@@ -1,0 +1,150 @@
+// Use this package for finding the damage type in the context of a
+// DamageDetection handler. Typically this means differentiating between spells
+// and basic attacks.
+package DamageType
+    import DamageDetection
+    import AbilityObjEditing
+    import TempGroups
+
+
+    class DelayDat
+        unit target
+        unit source
+        real damage
+
+
+    public class DamageType
+        static constant int NULLED = -1
+        static constant int ATTACK =  0
+        static constant int SPELL  =  1
+        static constant int CODE   =  2
+
+        // ConvertAttackType(7) is a hidden attack type with some unique
+        // properties. For more information see goo.gl/9k8tn .
+        private static constant attacktype ATTACK_TYPE_UNIVERSAL = ConvertAttackType(7)
+        private static constant int        DAMAGE_TYPE_CHECK_ID  = '!dt*'
+        private static constant real       DELAY_AMOUNT          = 0.
+
+
+        private static bool useBonusCalculator = false
+        static function setUseBonusCalculator(bool use)
+            useBonusCalculator = use
+
+
+        private static int lastDamageType = NULLED
+        static function get() returns int
+            let sourceDamage = GetEventDamage()
+            if lastDamageType == CODE
+                return CODE
+            else if sourceDamage > 0.
+                return ATTACK
+            else if sourceDamage < 0.
+                return SPELL
+
+            return NULLED
+
+
+        static function dealCodeDamage(unit who, unit target, real damage)
+            let prevType   = lastDamageType
+            let hp         = target.getHP() - .405
+            lastDamageType = CODE
+
+            if hp > damage
+                target.setHP(hp - damage + .405)
+                UnitDamageTarget(who, target, 0. , true, false, ATTACK_TYPE_UNIVERSAL, DAMAGE_TYPE_UNIVERSAL, null)
+            else
+                UnitDamageTarget(who, target, 1000000. + damage, true, false, ATTACK_TYPE_UNIVERSAL, DAMAGE_TYPE_UNIVERSAL, null)
+
+                // Also deal magic damage for the special case of ethereal
+                // units.
+                UnitDamageTarget(who, target, 1000000. + damage, true, false, ATTACK_TYPE_MAGIC,     DAMAGE_TYPE_UNIVERSAL, null)
+
+            lastDamageType = prevType
+
+
+        protected static function c() returns bool
+            GetTriggerUnit()..addAbility(DAMAGE_TYPE_CHECK_ID)
+                            ..makeAbilityPermanent(DAMAGE_TYPE_CHECK_ID, true)
+
+            return false
+
+
+        private static function after()
+            let      time    = GetExpiredTimer()
+            DelayDat tempDat = time.getData() castTo DelayDat
+
+            dealCodeDamage(tempDat.source, tempDat.target, tempDat.damage)
+
+            destroy tempDat
+            DestroyTimer(time)
+
+
+        private static function getUnitBonusSpellResistance(unit u) returns real
+            let prevType = lastDamageType
+            let life     = u.getHP()
+            var scale    = u.getMaxHP()
+
+            u.setHP(scale)
+            lastDamageType = CODE
+            UnitDamageTarget(u, u, -scale/2., false, false, null, DAMAGE_TYPE_UNIVERSAL, null)
+            scale = 2.*(scale - u.getHP())/scale
+            u.setHP(life)
+
+            lastDamageType = prevType
+            return scale
+
+
+        // This is the method that will invert any negative spell damage. To
+        // function properly, it *must* be the first handler in the
+        // DamageDetection handlers. To ensure this, simply import DamageType
+        // in any package where you also import DamageDetection (so long as you
+        // require the DamageType feature).
+        protected static function handler() returns bool
+            if get() == SPELL
+                var attemptedDamage = -1.*GetEventDamage()
+                let tU              = GetTriggerUnit()
+
+                if useBonusCalculator
+                    let scale = getUnitBonusSpellResistance(tU)
+
+                    if scale > 1.
+                        attemptedDamage = attemptedDamage*(scale + 1.)/2.
+
+
+                let sampledLife = tU.getHP() - .405
+                if sampledLife >= attemptedDamage and sampledLife <= 2.*attemptedDamage
+                    tU.setHP(sampledLife - attemptedDamage)
+
+                    let tempDat = new DelayDat
+                    tempDat.target = tU
+                    tempDat.source = GetEventDamageSource()
+                    tempDat.damage = attemptedDamage
+
+                    CreateTimer()..setData(tempDat castTo int)
+                                 ..start(DELAY_AMOUNT, function after)
+                else
+                    dealCodeDamage(GetEventDamageSource(), tU, 2.*attemptedDamage)
+
+            return false
+
+
+    init
+        let reg = CreateRegion()..addRect(bj_mapInitialPlayableArea)
+        CreateTrigger()..registerEnterRegion(reg, null)
+                       ..addCondition(Condition(function DamageType.c))
+
+        GroupEnumUnitsInRect(ENUM_GROUP, bj_mapInitialPlayableArea, null)
+        for iter in ENUM_GROUP
+            iter..addAbility(          DamageType.DAMAGE_TYPE_CHECK_ID)
+                ..makeAbilityPermanent(DamageType.DAMAGE_TYPE_CHECK_ID)
+        ENUM_GROUP.clear()
+
+        addOnDamageFunc(Condition(function DamageType.handler))
+
+
+    @compiletime function generateAbility()
+        new AbilityDefinitionRunedBracers(DamageType.DAMAGE_TYPE_CHECK_ID)
+            ..setName("Runed Bracer Dummy")
+            ..setEditorSuffix("(DamageType)")
+            ..setItemAbility(false)
+            ..setDamageReduction(1, 2.)

--- a/Wurstpack/wurstscript/lib/systems/DamageType.wurst
+++ b/Wurstpack/wurstscript/lib/systems/DamageType.wurst
@@ -7,138 +7,137 @@ package DamageType
     import DamageDetection
     import OnUnitEnterLeave
 
-
     class DelayDat
         unit target
         unit source
         real damage
 
 
-    public class DamageType
-        static constant int NULLED = -1
-        static constant int ATTACK =  0
-        static constant int SPELL  =  1
-        static constant int CODE   =  2
-
-        // ConvertAttackType(7) is a hidden attack type with some unique
-        // properties. For more information see goo.gl/9k8tn .
-        private   static constant ATTACK_TYPE_UNIVERSAL = ConvertAttackType(7)
-        protected static constant DAMAGE_TYPE_CHECK_ID  = '!dt*'
-        private   static constant DELAY_AMOUNT          = 0.
+    public enum DamageType
+        NULLED
+        ATTACK
+        SPELL
+        CODE
 
 
-        static var useBonusCalculator = false
+    @configurable var useBonusCalculator = false
 
 
-        private static int lastDamageType = NULLED
-        static function get() returns int
-            let sourceDamage = GetEventDamage()
-            if lastDamageType == CODE
-                return CODE
-            else if sourceDamage > 0.
-                return ATTACK
-            else if sourceDamage < 0.
-                return SPELL
-
-            return NULLED
+    // ConvertAttackType(7) is a hidden attack type with some unique
+    // properties. For more information see goo.gl/9k8tn .
+    constant ATTACK_TYPE_UNIVERSAL = ConvertAttackType(7)
+    constant DAMAGE_TYPE_CHECK_ID  = '!dt*'
 
 
-        static function dealCodeDamage(unit who, unit target, real damage)
-            let prevType   = lastDamageType
-            let hp         = target.getHP() - .405
-            lastDamageType = CODE
+    var lastDamageType = DamageType.NULLED
+    function getDamageType() returns DamageType
+        let sourceDamage = GetEventDamage()
+        if lastDamageType == DamageType.CODE
+            return DamageType.CODE
+        else if sourceDamage > 0.
+            return DamageType.ATTACK
+        else if sourceDamage < 0.
+            return DamageType.SPELL
 
-            if hp > damage
-                target.setHP(hp - damage + .405)
-                UnitDamageTarget(who, target, 0. , true, false, ATTACK_TYPE_UNIVERSAL, DAMAGE_TYPE_UNIVERSAL, null)
+        return DamageType.NULLED
+
+
+    function dealCodeDamage(unit who, unit target, real damage)
+        let prevType   = lastDamageType
+        let hp         = target.getHP() - .405
+        lastDamageType = DamageType.CODE
+
+        if hp > damage
+            target.setHP(hp - damage + .405)
+            UnitDamageTarget(who, target, 0. , true, false, ATTACK_TYPE_UNIVERSAL, DAMAGE_TYPE_UNIVERSAL, null)
+        else
+            // Deal damage using two separate components. The
+            // ATTACK_TYPE_UNIVERSAL case will deal damage to units of all armor
+            // types, even if that armor would otherwise block all damage. The
+            // ATTACK_TYPE_MAGIC case affect ethereal units, whereas other
+            // attack types do not.
+            UnitDamageTarget(who, target, 1000000. + damage, true, false, ATTACK_TYPE_UNIVERSAL, DAMAGE_TYPE_UNIVERSAL, null)
+            UnitDamageTarget(who, target, 1000000. + damage, true, false, ATTACK_TYPE_MAGIC,     DAMAGE_TYPE_UNIVERSAL, null)
+
+        lastDamageType = prevType
+
+
+    function after()
+        let      time    = GetExpiredTimer()
+        DelayDat tempDat = time.getData() castTo DelayDat
+
+        dealCodeDamage(tempDat.source, tempDat.target, tempDat.damage)
+
+        destroy tempDat
+        DestroyTimer(time)
+
+
+    function getUnitBonusSpellResistance(unit u) returns real
+        let prevType = lastDamageType
+        let life     = u.getHP()
+        var scale    = u.getMaxHP()
+
+        u.setHP(scale)
+        lastDamageType = CODE
+        UnitDamageTarget(u, u, -scale/2., false, false, null, DAMAGE_TYPE_UNIVERSAL, null)
+        scale = 2.*(scale - u.getHP())/scale
+        u.setHP(life)
+
+        lastDamageType = prevType
+        return scale
+
+
+    // This is the method that will invert any negative spell damage. To
+    // function properly, it *must* be the first handler in the
+    // DamageDetection handlers. To ensure this, simply import DamageType
+    // in any package where you also import DamageDetection (so long as you
+    // require the DamageType feature).
+    function handler() returns bool
+        if getDamageType() == DamageType.SPELL
+            var attemptedDamage = -1.*GetEventDamage()
+            let tU              = GetTriggerUnit()
+
+            if useBonusCalculator
+                let scale = getUnitBonusSpellResistance(tU)
+
+                if scale > 1.
+                    attemptedDamage = attemptedDamage*(scale + 1.)/2.
+
+
+            let sampledLife = tU.getHP() - .405
+            if sampledLife >= attemptedDamage and sampledLife <= 2.*attemptedDamage
+                tU.setHP(sampledLife - attemptedDamage)
+
+                let tempDat = new DelayDat
+                tempDat.target = tU
+                tempDat.source = GetEventDamageSource()
+                tempDat.damage = attemptedDamage
+
+                CreateTimer()..setData(tempDat castTo int)
+                             ..start(0., function after)
             else
-                UnitDamageTarget(who, target, 1000000. + damage, true, false, ATTACK_TYPE_UNIVERSAL, DAMAGE_TYPE_UNIVERSAL, null)
+                dealCodeDamage(GetEventDamageSource(), tU, 2.*attemptedDamage)
 
-                // Also deal magic damage for the special case of ethereal
-                // units.
-                UnitDamageTarget(who, target, 1000000. + damage, true, false, ATTACK_TYPE_MAGIC,     DAMAGE_TYPE_UNIVERSAL, null)
-
-            lastDamageType = prevType
+        return false
 
 
-        protected static function c() returns bool
+    init
+        onEnter(() -> begin
             GetTriggerUnit()..addAbility(          DAMAGE_TYPE_CHECK_ID)
                             ..makeAbilityPermanent(DAMAGE_TYPE_CHECK_ID, true)
 
             return false
-
-
-        private static function after()
-            let      time    = GetExpiredTimer()
-            DelayDat tempDat = time.getData() castTo DelayDat
-
-            dealCodeDamage(tempDat.source, tempDat.target, tempDat.damage)
-
-            destroy tempDat
-            DestroyTimer(time)
-
-
-        private static function getUnitBonusSpellResistance(unit u) returns real
-            let prevType = lastDamageType
-            let life     = u.getHP()
-            var scale    = u.getMaxHP()
-
-            u.setHP(scale)
-            lastDamageType = CODE
-            UnitDamageTarget(u, u, -scale/2., false, false, null, DAMAGE_TYPE_UNIVERSAL, null)
-            scale = 2.*(scale - u.getHP())/scale
-            u.setHP(life)
-
-            lastDamageType = prevType
-            return scale
-
-
-        // This is the method that will invert any negative spell damage. To
-        // function properly, it *must* be the first handler in the
-        // DamageDetection handlers. To ensure this, simply import DamageType
-        // in any package where you also import DamageDetection (so long as you
-        // require the DamageType feature).
-        protected static function handler() returns bool
-            if get() == SPELL
-                var attemptedDamage = -1.*GetEventDamage()
-                let tU              = GetTriggerUnit()
-
-                if useBonusCalculator
-                    let scale = getUnitBonusSpellResistance(tU)
-
-                    if scale > 1.
-                        attemptedDamage = attemptedDamage*(scale + 1.)/2.
-
-
-                let sampledLife = tU.getHP() - .405
-                if sampledLife >= attemptedDamage and sampledLife <= 2.*attemptedDamage
-                    tU.setHP(sampledLife - attemptedDamage)
-
-                    let tempDat = new DelayDat
-                    tempDat.target = tU
-                    tempDat.source = GetEventDamageSource()
-                    tempDat.damage = attemptedDamage
-
-                    CreateTimer()..setData(tempDat castTo int)
-                                 ..start(DELAY_AMOUNT, function after)
-                else
-                    dealCodeDamage(GetEventDamageSource(), tU, 2.*attemptedDamage)
-
-            return false
-
-
-    init
-        onEnter(function DamageType.c)
+        end)
         forUnitsInRect(bj_mapInitialPlayableArea, (unit iter) -> begin
-            iter..addAbility(          DamageType.DAMAGE_TYPE_CHECK_ID)
-                ..makeAbilityPermanent(DamageType.DAMAGE_TYPE_CHECK_ID, true)
+            iter..addAbility(          DAMAGE_TYPE_CHECK_ID)
+                ..makeAbilityPermanent(DAMAGE_TYPE_CHECK_ID, true)
         end)
 
-        addOnDamageFunc(Condition(function DamageType.handler))
+        addOnDamageFunc(Condition(function handler))
 
 
     @compiletime function generateAbility()
-        new AbilityDefinitionRunedBracers(DamageType.DAMAGE_TYPE_CHECK_ID)
+        new AbilityDefinitionRunedBracers(DAMAGE_TYPE_CHECK_ID)
             ..setName("Runed Bracer Dummy")
             ..setEditorSuffix("(DamageType)")
             ..setItemAbility(false)

--- a/Wurstpack/wurstscript/lib/systems/DamageType.wurst
+++ b/Wurstpack/wurstscript/lib/systems/DamageType.wurst
@@ -2,9 +2,10 @@
 // DamageDetection handler. Typically this means differentiating between spells
 // and basic attacks.
 package DamageType
-    import DamageDetection
     import AbilityObjEditing
-    import TempGroups
+    import ClosureForGroups
+    import DamageDetection
+    import OnUnitEnterLeave
 
 
     class DelayDat
@@ -21,14 +22,12 @@ package DamageType
 
         // ConvertAttackType(7) is a hidden attack type with some unique
         // properties. For more information see goo.gl/9k8tn .
-        private static constant attacktype ATTACK_TYPE_UNIVERSAL = ConvertAttackType(7)
-        private static constant int        DAMAGE_TYPE_CHECK_ID  = '!dt*'
-        private static constant real       DELAY_AMOUNT          = 0.
+        private   static constant ATTACK_TYPE_UNIVERSAL = ConvertAttackType(7)
+        protected static constant DAMAGE_TYPE_CHECK_ID  = '!dt*'
+        private   static constant DELAY_AMOUNT          = 0.
 
 
-        private static bool useBonusCalculator = false
-        static function setUseBonusCalculator(bool use)
-            useBonusCalculator = use
+        static var useBonusCalculator = false
 
 
         private static int lastDamageType = NULLED
@@ -63,7 +62,7 @@ package DamageType
 
 
         protected static function c() returns bool
-            GetTriggerUnit()..addAbility(DAMAGE_TYPE_CHECK_ID)
+            GetTriggerUnit()..addAbility(          DAMAGE_TYPE_CHECK_ID)
                             ..makeAbilityPermanent(DAMAGE_TYPE_CHECK_ID, true)
 
             return false
@@ -129,15 +128,11 @@ package DamageType
 
 
     init
-        let reg = CreateRegion()..addRect(bj_mapInitialPlayableArea)
-        CreateTrigger()..registerEnterRegion(reg, null)
-                       ..addCondition(Condition(function DamageType.c))
-
-        GroupEnumUnitsInRect(ENUM_GROUP, bj_mapInitialPlayableArea, null)
-        for iter in ENUM_GROUP
+        onEnter(function DamageType.c)
+        forUnitsInRect(bj_mapInitialPlayableArea, (unit iter) -> begin
             iter..addAbility(          DamageType.DAMAGE_TYPE_CHECK_ID)
-                ..makeAbilityPermanent(DamageType.DAMAGE_TYPE_CHECK_ID)
-        ENUM_GROUP.clear()
+                ..makeAbilityPermanent(DamageType.DAMAGE_TYPE_CHECK_ID, true)
+        end)
 
         addOnDamageFunc(Condition(function DamageType.handler))
 

--- a/Wurstpack/wurstscript/lib/systems/DamageType.wurst
+++ b/Wurstpack/wurstscript/lib/systems/DamageType.wurst
@@ -24,14 +24,42 @@ public enum DamageType
 @configurable var useBonusCalculator = false
 
 
-// ConvertAttackType(7) is a hidden attack type with some unique
-// properties. For more information see goo.gl/9k8tn .
+// ConvertAttackType(7) is a hidden attack type with some unique properties. For
+// more information see goo.gl/9k8tn .
 constant ATTACK_TYPE_UNIVERSAL = ConvertAttackType(7)
 constant DAMAGE_TYPE_CHECK_ID  = '!dt*'
 
 
 var lastDamageType = DamageType.NULLED
-function getDamageType() returns DamageType
+/** In the context of a damage detection handler, get the type of damage dealt.
+    Returns one of:
+
+        DamageType.CODE
+        DamageType.ATTACK
+        DamageType.SPELL
+        DamageType.NULLED
+
+    Be sure that if you use the `DamageType` package, that all subscribers of
+    `DamageDetection` also `import DamageType`, or you may experience race
+    conditions.
+
+    Example Usage:
+
+        import DamageDetection
+        import DamageType
+
+        init
+            addOnDamageFunc(Condition(() -> begin
+                switch getDamageType()
+                    case ATTACK
+                        print(GetEventDamageSource().getName() + " attacked " + GetTriggerUnit().getName())
+                    case SPELL
+                        print(GetEventDamageSource().getName() + " used a sell on " + GetTriggerUnit().getName())
+                    default
+                        skip
+            end))
+*/
+public function getDamageType() returns DamageType
     let sourceDamage = GetEventDamage()
     if lastDamageType == DamageType.CODE
         return DamageType.CODE
@@ -43,7 +71,13 @@ function getDamageType() returns DamageType
     return DamageType.NULLED
 
 
-function dealCodeDamage(unit who, unit target, real damage)
+/** Deal an exact amount of damage to `target`, crediting kill experience and
+    gold bounty to `who`.
+
+    Be sure that if you use the `DamageType` package, that all subscribers of
+    `DamageDetection` also `import DamageType`, or you may experience race
+    conditions. */
+public function dealCodeDamage(unit who, unit target, real damage)
     let prevType   = lastDamageType
     let hp         = target.getHP() - .405
     lastDamageType = DamageType.CODE
@@ -52,11 +86,10 @@ function dealCodeDamage(unit who, unit target, real damage)
         target.setHP(hp - damage + .405)
         UnitDamageTarget(who, target, 0. , true, false, ATTACK_TYPE_UNIVERSAL, DAMAGE_TYPE_UNIVERSAL, null)
     else
-        // Deal damage using two separate components. The
-        // ATTACK_TYPE_UNIVERSAL case will deal damage to units of all armor
-        // types, even if that armor would otherwise block all damage. The
-        // ATTACK_TYPE_MAGIC case affect ethereal units, whereas other
-        // attack types do not.
+        // Deal damage using two separate components. The ATTACK_TYPE_UNIVERSAL
+        // case will deal damage to units of all armor types, even if that armor
+        // would otherwise block all damage. The ATTACK_TYPE_MAGIC case affect
+        // ethereal units, whereas other attack types do not.
         UnitDamageTarget(who, target, 1000000. + damage, true, false, ATTACK_TYPE_UNIVERSAL, DAMAGE_TYPE_UNIVERSAL, null)
         UnitDamageTarget(who, target, 1000000. + damage, true, false, ATTACK_TYPE_MAGIC,     DAMAGE_TYPE_UNIVERSAL, null)
 
@@ -88,11 +121,10 @@ function getUnitBonusSpellResistance(unit u) returns real
     return scale
 
 
-// This is the method that will invert any negative spell damage. To
-// function properly, it *must* be the first handler in the
-// DamageDetection handlers. To ensure this, simply import DamageType
-// in any package where you also import DamageDetection (so long as you
-// require the DamageType feature).
+// This is the method that will invert any negative spell damage. To function
+// properly, it *must* be the first handler in the DamageDetection handlers. To
+// ensure this, simply import DamageType in any package where you also import
+// DamageDetection (so long as you require the DamageType feature).
 function handler() returns bool
     if getDamageType() == DamageType.SPELL
         var attemptedDamage = -1.*GetEventDamage()


### PR DESCRIPTION
This is an implementation of DamageType, a system designed by
looking_for_help which uses the runed bracer ability to differentiate
basic attacks from spell damage in the context of a damage event. This
script is a conersion of DamageType by Cokemonkey11, and adjusted to
use Wurst DamageDetection instead of StructuredDD (vJass).

Untested.